### PR TITLE
[ReactJS-IoC-v1.2.4] Fix `Cannot use 'in' operator to search for 'children'` when `children` is undefined  + Update `dev` deps

### DIFF
--- a/libs/react-js/ioc/package.json
+++ b/libs/react-js/ioc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@norabytes/reactjs-ioc",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "author": "Adi-Marian Mutu <adi.mutu@norabytes.com>",
   "description": "A simple Inversion of Control library for ReactJS built on top of the injection-js library.",
   "homepage": "https://github.com/NoraBytes/NoraBytes/tree/main/libs/react-js/ioc#readme",
@@ -28,8 +28,8 @@
     "injection-js": "2.4.0"
   },
   "devDependencies": {
-    "type-fest": "^4.21.0",
-    "typescript": "^4.7.0"
+    "type-fest": "^4.30.0",
+    "typescript": "^5.7.2"
   },
   "type": "commonjs",
   "main": "./dist/src/index.js",

--- a/libs/react-js/ioc/src/react/helpers/props-without-children.ts
+++ b/libs/react-js/ioc/src/react/helpers/props-without-children.ts
@@ -1,7 +1,8 @@
 import type * as AdvancedTypes from 'type-fest';
 
 /** Helper method which can be used to remove the `children` property from the provided {@link props}. */
-export function propsWithoutChildren<T extends Record<string, any>>(props: T): PropsWithoutChildrenReturn<T> {
+export function propsWithoutChildren<T extends Record<string, any>>(props?: T): PropsWithoutChildrenReturn<T> {
+  // props = props ?? ({} as any);
   const hasChildren = 'children' in props;
 
   if (!hasChildren) return props;

--- a/libs/react-js/ioc/src/react/injector-provider.tsx
+++ b/libs/react-js/ioc/src/react/injector-provider.tsx
@@ -28,7 +28,7 @@ export function InjectorProvider({
   preInjection,
 }: InjectorProviderProps) {
   const contextInjector = useInjectInternal({ module, injectInto, provideInjectorContainer });
-  const childrenProps = propsWithoutChildren(children?.props);
+  const childrenProps = propsWithoutChildren();
 
   const Renderer = useCallback(() => {
     preInjection?.();

--- a/libs/react-js/ioc/src/tests/react-js.spec.tsx
+++ b/libs/react-js/ioc/src/tests/react-js.spec.tsx
@@ -6,6 +6,7 @@ import '@testing-library/jest-dom';
 import { Injector } from '../injector';
 import { ComponentMock, Module, ServiceMock } from './mocks';
 import type { InjectorContainer } from '../types';
+import { InjectorProvider } from '../react';
 
 export const TEST_ID = 'reactjs-ioc';
 
@@ -49,5 +50,17 @@ describe('ReactJS ReflexiveStore', () => {
     const container = await screen.findByTestId(TEST_ID);
 
     expect(container.querySelector('h2')?.innerHTML).toBe('1');
+  });
+
+  it('should NOT fail when children.props does not exist', async () => {
+    await act(async () =>
+      render(
+        <InjectorProvider module={Module} provideInjectorContainer={injectorContainer}>
+          <hr />
+        </InjectorProvider>
+      )
+    );
+
+    expect(true).toBe(true);
   });
 });


### PR DESCRIPTION
+ Update `dev` deps